### PR TITLE
Undo addition of whitespace to improve readability

### DIFF
--- a/example/server/liquid_servlet.rb
+++ b/example/server/liquid_servlet.rb
@@ -20,8 +20,8 @@ class LiquidServlet < WEBrick::HTTPServlet::AbstractServlet
     @assigns = send(@action) if respond_to?(@action)
 
     @response['Content-Type'] = "text/html"
-    @response.status          = 200
-    @response.body            = Liquid::Template.parse(read_template).render(@assigns, filters: [ProductsFilter])
+    @response.status = 200
+    @response.body   = Liquid::Template.parse(read_template).render(@assigns, filters: [ProductsFilter])
   end
 
   def read_template(filename = @action)

--- a/lib/liquid/block_body.rb
+++ b/lib/liquid/block_body.rb
@@ -34,8 +34,8 @@ module Liquid
             # caller raise a syntax error
             return yield token, token
           end
-          tag_name    = Regexp.last_match(1)
-          markup      = Regexp.last_match(2)
+          tag_name = Regexp.last_match(1)
+          markup   = Regexp.last_match(2)
           unless (tag = registered_tags[tag_name])
             # end parsing if we reach an unknown tag and let the caller decide
             # determine how to proceed
@@ -79,8 +79,8 @@ module Liquid
             # determine how to proceed
             return yield tag_name, markup
           end
-          new_tag     = tag.parse(tag_name, markup, tokenizer, parse_context)
-          @blank    &&= new_tag.blank?
+          new_tag = tag.parse(tag_name, markup, tokenizer, parse_context)
+          @blank &&= new_tag.blank?
           @nodelist << new_tag
         when token.start_with?(VARSTART)
           whitespace_handler(token, parse_context)
@@ -121,7 +121,7 @@ module Liquid
     def render_to_output_buffer(context, output)
       context.resource_limits.render_score += @nodelist.length
 
-      idx         = 0
+      idx = 0
       while (node = @nodelist[idx])
         previous_output_size = output.bytesize
 

--- a/lib/liquid/condition.rb
+++ b/lib/liquid/condition.rb
@@ -35,16 +35,17 @@ module Liquid
     attr_accessor :left, :operator, :right
 
     def initialize(left = nil, operator = nil, right = nil)
-      @left            = left
-      @operator        = operator
-      @right           = right
+      @left     = left
+      @operator = operator
+      @right    = right
+
       @child_relation  = nil
       @child_condition = nil
     end
 
     def evaluate(context = Context.new)
       condition = self
-      result    = nil
+      result = nil
       loop do
         result = interpret_condition(condition.left, condition.right, condition.operator, context)
 

--- a/lib/liquid/context.rb
+++ b/lib/liquid/context.rb
@@ -60,7 +60,7 @@ module Liquid
     # Note that this does not register the filters with the main Template object. see <tt>Template.register_filter</tt>
     # for that
     def add_filters(filters)
-      filters   = [filters].flatten.compact
+      filters = [filters].flatten.compact
       @filters += filters
       @strainer = nil
     end
@@ -85,7 +85,7 @@ module Liquid
     end
 
     def handle_error(e, line_number = nil)
-      e                 = internal_error unless e.is_a?(Liquid::Error)
+      e = internal_error unless e.is_a?(Liquid::Error)
       e.template_name ||= template_name
       e.line_number   ||= line_number
       errors.push(e)
@@ -140,10 +140,10 @@ module Liquid
       ).tap do |subcontext|
         subcontext.base_scope_depth   = base_scope_depth + 1
         subcontext.exception_renderer = exception_renderer
-        subcontext.filters            = @filters
-        subcontext.strainer           = nil
-        subcontext.errors             = errors
-        subcontext.warnings           = warnings
+        subcontext.filters  = @filters
+        subcontext.strainer = nil
+        subcontext.errors   = errors
+        subcontext.warnings = warnings
       end
     end
 

--- a/lib/liquid/expression.rb
+++ b/lib/liquid/expression.rb
@@ -7,7 +7,7 @@ module Liquid
 
       def initialize(method_name, to_s)
         @method_name = method_name
-        @to_s        = to_s
+        @to_s = to_s
       end
 
       def to_liquid

--- a/lib/liquid/parse_context.rb
+++ b/lib/liquid/parse_context.rb
@@ -7,10 +7,12 @@ module Liquid
 
     def initialize(options = {})
       @template_options = options ? options.dup : {}
-      @locale           = @template_options[:locale] ||= I18n.new
-      @warnings         = []
-      self.depth        = 0
-      self.partial      = false
+
+      @locale   = @template_options[:locale] ||= I18n.new
+      @warnings = []
+
+      self.depth   = 0
+      self.partial = false
     end
 
     def [](option_key)
@@ -18,8 +20,9 @@ module Liquid
     end
 
     def partial=(value)
-      @partial    = value
-      @options    = value ? partial_options : @template_options
+      @partial = value
+      @options = value ? partial_options : @template_options
+
       @error_mode = @options[:error_mode] || Template.error_mode
     end
 

--- a/lib/liquid/partial_cache.rb
+++ b/lib/liquid/partial_cache.rb
@@ -4,14 +4,15 @@ module Liquid
   class PartialCache
     def self.load(template_name, context:, parse_context:)
       cached_partials = (context.registers[:cached_partials] ||= {})
-      cached          = cached_partials[template_name]
+      cached = cached_partials[template_name]
       return cached if cached
 
-      file_system           = (context.registers[:file_system] ||= Liquid::Template.file_system)
-      source                = file_system.read_template_file(template_name)
+      file_system = (context.registers[:file_system] ||= Liquid::Template.file_system)
+      source      = file_system.read_template_file(template_name)
+
       parse_context.partial = true
 
-      partial                        = Liquid::Template.parse(source, parse_context)
+      partial = Liquid::Template.parse(source, parse_context)
       cached_partials[template_name] = partial
     ensure
       parse_context.partial = false

--- a/lib/liquid/profiler.rb
+++ b/lib/liquid/profiler.rb
@@ -121,12 +121,12 @@ module Liquid
 
     def start
       Thread.current[:liquid_profiler] = self
-      @render_start_at                 = Time.now
+      @render_start_at = Time.now
     end
 
     def stop
       Thread.current[:liquid_profiler] = nil
-      @render_end_at                   = Time.now
+      @render_end_at = Time.now
     end
 
     def total_render_time

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -76,11 +76,14 @@ module Liquid
     # Truncate a string down to x characters
     def truncate(input, length = 50, truncate_string = "...")
       return if input.nil?
-      input_str           = input.to_s
-      length              = Utils.to_integer(length)
+      input_str = input.to_s
+      length    = Utils.to_integer(length)
+
       truncate_string_str = truncate_string.to_s
-      l                   = length - truncate_string_str.length
-      l                   = 0 if l < 0
+
+      l = length - truncate_string_str.length
+      l = 0 if l < 0
+
       input_str.length > length ? input_str[0...l].concat(truncate_string_str) : input_str
     end
 
@@ -88,8 +91,10 @@ module Liquid
       return if input.nil?
       wordlist = input.to_s.split
       words    = Utils.to_integer(words)
-      l        = words - 1
-      l        = 0 if l < 0
+
+      l = words - 1
+      l = 0 if l < 0
+
       wordlist.length > l ? wordlist[0..l].join(" ").concat(truncate_string.to_s) : input
     end
 
@@ -432,7 +437,7 @@ module Liquid
     #    {{ product.title | default: "No Title", allow_false: true }}
     #
     def default(input, default_value = '', options = {})
-      options     = {} unless options.is_a?(Hash)
+      options = {} unless options.is_a?(Hash)
       false_check = options['allow_false'] ? input.nil? : !input
       false_check || (input.respond_to?(:empty?) && input.empty?) ? default_value : input
     end

--- a/lib/liquid/tablerowloop_drop.rb
+++ b/lib/liquid/tablerowloop_drop.rb
@@ -54,7 +54,7 @@ module Liquid
       @index += 1
 
       if @col == @cols
-        @col  = 1
+        @col = 1
         @row += 1
       else
         @col += 1

--- a/lib/liquid/tags/assign.rb
+++ b/lib/liquid/tags/assign.rb
@@ -29,8 +29,8 @@ module Liquid
     end
 
     def render_to_output_buffer(context, output)
-      val                                   = @from.render(context)
-      context.scopes.last[@to]              = val
+      val = @from.render(context)
+      context.scopes.last[@to] = val
       context.resource_limits.assign_score += assign_score_of(val)
       output
     end
@@ -45,7 +45,7 @@ module Liquid
       if val.instance_of?(String)
         val.bytesize
       elsif val.instance_of?(Array) || val.instance_of?(Hash)
-        sum                     = 1
+        sum = 1
         # Uses #each to avoid extra allocations.
         val.each { |child| sum += assign_score_of(child) }
         sum

--- a/lib/liquid/tags/capture.rb
+++ b/lib/liquid/tags/capture.rb
@@ -27,7 +27,7 @@ module Liquid
     def render_to_output_buffer(context, output)
       previous_output_size = output.bytesize
       super
-      context.scopes.last[@to]              = output
+      context.scopes.last[@to] = output
       context.resource_limits.assign_score += (output.bytesize - previous_output_size)
       output
     end

--- a/lib/liquid/tags/cycle.rb
+++ b/lib/liquid/tags/cycle.rb
@@ -49,10 +49,10 @@ module Liquid
 
       output << val
 
-      iteration                     += 1
-      iteration                      = 0 if iteration >= @variables.size
-      context.registers[:cycle][key] = iteration
+      iteration += 1
+      iteration = 0 if iteration >= @variables.size
 
+      context.registers[:cycle][key] = iteration
       output
     end
 

--- a/lib/liquid/tags/for.rb
+++ b/lib/liquid/tags/for.rb
@@ -102,13 +102,15 @@ module Liquid
     end
 
     def strict_parse(markup)
-      p                = Parser.new(markup)
-      @variable_name   = p.consume(:id)
+      p = Parser.new(markup)
+      @variable_name = p.consume(:id)
       raise SyntaxError, options[:locale].t("errors.syntax.for_invalid_in") unless p.id?('in')
+
       collection_name  = p.expression
-      @name            = "#{@variable_name}-#{collection_name}"
       @collection_name = Expression.parse(collection_name)
-      @reversed        = p.id?('reversed')
+
+      @name     = "#{@variable_name}-#{collection_name}"
+      @reversed = p.id?('reversed')
 
       while p.look(:id) && p.look(:colon, 1)
         unless (attribute = p.id?('limit') || p.id?('offset'))
@@ -140,7 +142,7 @@ module Liquid
       collection = collection.to_a if collection.is_a?(Range)
 
       limit_value = context.evaluate(@limit)
-      to          = if limit_value.nil?
+      to = if limit_value.nil?
         nil
       else
         Utils.to_integer(limit_value) + from

--- a/lib/liquid/tags/if.rb
+++ b/lib/liquid/tags/if.rb
@@ -85,16 +85,16 @@ module Liquid
     end
 
     def strict_parse(markup)
-      p         = Parser.new(markup)
+      p = Parser.new(markup)
       condition = parse_binary_comparisons(p)
       p.consume(:end_of_string)
       condition
     end
 
     def parse_binary_comparisons(p)
-      condition       = parse_comparison(p)
+      condition = parse_comparison(p)
       first_condition = condition
-      while (op       = (p.id?('and') || p.id?('or')))
+      while (op = (p.id?('and') || p.id?('or')))
         child_condition = parse_comparison(p)
         condition.send(op, child_condition)
         condition = child_condition
@@ -103,7 +103,7 @@ module Liquid
     end
 
     def parse_comparison(p)
-      a      = Expression.parse(p.expression)
+      a = Expression.parse(p.expression)
       if (op = p.consume?(:comparison))
         b = Expression.parse(p.expression)
         Condition.new(a, op, b)

--- a/lib/liquid/tags/increment.rb
+++ b/lib/liquid/tags/increment.rb
@@ -23,7 +23,7 @@ module Liquid
     end
 
     def render_to_output_buffer(context, output)
-      value                                 = context.environments.first[@variable] ||= 0
+      value = context.environments.first[@variable] ||= 0
       context.environments.first[@variable] = value + 1
 
       output << value.to_s

--- a/lib/liquid/tags/raw.rb
+++ b/lib/liquid/tags/raw.rb
@@ -2,7 +2,7 @@
 
 module Liquid
   class Raw < Block
-    Syntax                   = /\A\s*\z/
+    Syntax = /\A\s*\z/
     FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om
 
     def initialize(tag_name, markup, parse_context)
@@ -12,7 +12,7 @@ module Liquid
     end
 
     def parse(tokens)
-      @body        = +''
+      @body = +''
       while (token = tokens.shift)
         if token =~ FullTokenPossiblyInvalid
           @body << Regexp.last_match(1) if Regexp.last_match(1) != ""

--- a/lib/liquid/tags/render.rb
+++ b/lib/liquid/tags/render.rb
@@ -16,7 +16,7 @@ module Liquid
       template_name = Regexp.last_match(1)
       variable_name = Regexp.last_match(3)
 
-      @alias_name         = Regexp.last_match(5)
+      @alias_name = Regexp.last_match(5)
       @variable_name_expr = variable_name ? Expression.parse(variable_name) : nil
       @template_name_expr = Expression.parse(template_name)
 
@@ -44,9 +44,10 @@ module Liquid
       context_variable_name = @alias_name || template_name.split('/').last
 
       render_partial_func = ->(var) {
-        inner_context                        = context.new_isolated_subcontext
-        inner_context.template_name          = template_name
-        inner_context.partial                = true
+        inner_context = context.new_isolated_subcontext
+        inner_context.template_name = template_name
+        inner_context.partial = true
+
         @attributes.each do |key, value|
           inner_context[key] = context.evaluate(value)
         end

--- a/lib/liquid/tags/table_row.rb
+++ b/lib/liquid/tags/table_row.rb
@@ -24,17 +24,16 @@ module Liquid
       (collection = context.evaluate(@collection_name)) || (return '')
 
       from = @attributes.key?('offset') ? context.evaluate(@attributes['offset']).to_i : 0
-      to   = @attributes.key?('limit') ? from + context.evaluate(@attributes['limit']).to_i : nil
+      to   = @attributes.key?('limit')  ? from + context.evaluate(@attributes['limit']).to_i : nil
 
       collection = Utils.slice_collection(collection, from, to)
-
-      length = collection.length
+      length     = collection.length
 
       cols = context.evaluate(@attributes['cols']).to_i
 
       output << "<tr class=\"row1\">\n"
       context.stack do
-        tablerowloop            = Liquid::TablerowloopDrop.new(length, cols)
+        tablerowloop = Liquid::TablerowloopDrop.new(length, cols)
         context['tablerowloop'] = tablerowloop
 
         collection.each do |item|

--- a/lib/liquid/variable.rb
+++ b/lib/liquid/variable.rb
@@ -61,7 +61,7 @@ module Liquid
 
     def strict_parse(markup)
       @filters = []
-      p        = Parser.new(markup)
+      p = Parser.new(markup)
 
       @name = Expression.parse(p.expression)
       while p.consume?(:pipe)

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -4,7 +4,7 @@ require 'benchmark/ips'
 require_relative 'theme_runner'
 
 Liquid::Template.error_mode = ARGV.first.to_sym if ARGV.first
-profiler                    = ThemeRunner.new
+profiler = ThemeRunner.new
 
 Benchmark.ips do |x|
   x.time   = 10

--- a/performance/profile.rb
+++ b/performance/profile.rb
@@ -4,7 +4,7 @@ require 'stackprof'
 require_relative 'theme_runner'
 
 Liquid::Template.error_mode = ARGV.first.to_sym if ARGV.first
-profiler                    = ThemeRunner.new
+profiler = ThemeRunner.new
 profiler.run
 
 [:cpu, :object].each do |profile_type|

--- a/test/integration/error_handling_test.rb
+++ b/test/integration/error_handling_test.rb
@@ -209,8 +209,8 @@ class ErrorHandlingTest < Minitest::Test
   end
 
   def test_setting_default_exception_renderer
-    old_exception_renderer                      = Liquid::Template.default_exception_renderer
-    exceptions                                  = []
+    old_exception_renderer = Liquid::Template.default_exception_renderer
+    exceptions = []
     Liquid::Template.default_exception_renderer = ->(e) {
       exceptions << e
       ''
@@ -252,8 +252,9 @@ class ErrorHandlingTest < Minitest::Test
 
     begin
       Liquid::Template.file_system = TestFileSystem.new
-      template                     = Liquid::Template.parse("Argument error:\n{% include 'product' %}", line_numbers: true)
-      page                         = template.render('errors' => ErrorDrop.new)
+
+      template = Liquid::Template.parse("Argument error:\n{% include 'product' %}", line_numbers: true)
+      page     = template.render('errors' => ErrorDrop.new)
     ensure
       Liquid::Template.file_system = old_file_system
     end

--- a/test/integration/filter_test.rb
+++ b/test/integration/filter_test.rb
@@ -72,10 +72,10 @@ class FiltersTest < Minitest::Test
   end
 
   def test_sort
-    @context['value']          = 3
-    @context['numbers']        = [2, 1, 4, 3]
-    @context['words']          = ['expected', 'as', 'alphabetic']
-    @context['arrays']         = ['flower', 'are']
+    @context['value']   = 3
+    @context['numbers'] = [2, 1, 4, 3]
+    @context['words']   = ['expected', 'as', 'alphabetic']
+    @context['arrays']  = ['flower', 'are']
     @context['case_sensitive'] = ['sensitive', 'Expected', 'case']
 
     assert_equal('1 2 3 4', Template.parse("{{numbers | sort | join}}").render(@context))

--- a/test/integration/tags/if_else_tag_test.rb
+++ b/test/integration/tags/if_else_tag_test.rb
@@ -142,7 +142,7 @@ class IfElseTagTest < Minitest::Test
   end
 
   def test_if_with_custom_condition
-    original_op                     = Condition.operators['contains']
+    original_op = Condition.operators['contains']
     Condition.operators['contains'] = :[]
 
     assert_template_result('yes', %({% if 'bob' contains 'o' %}yes{% endif %}))
@@ -152,7 +152,7 @@ class IfElseTagTest < Minitest::Test
   end
 
   def test_operators_are_ignored_unless_isolated
-    original_op                     = Condition.operators['contains']
+    original_op = Condition.operators['contains']
     Condition.operators['contains'] = :[]
 
     assert_template_result('yes',

--- a/test/integration/tags/include_tag_test.rb
+++ b/test/integration/tags/include_tag_test.rb
@@ -192,7 +192,7 @@ class IncludeTagTest < Minitest::Test
   end
 
   def test_custom_include_tag
-    original_tag                     = Liquid::Template.tags['include']
+    original_tag = Liquid::Template.tags['include']
     Liquid::Template.tags['include'] = CustomInclude
     begin
       assert_equal("custom_foo",
@@ -203,7 +203,7 @@ class IncludeTagTest < Minitest::Test
   end
 
   def test_custom_include_tag_within_if_statement
-    original_tag                     = Liquid::Template.tags['include']
+    original_tag = Liquid::Template.tags['include']
     Liquid::Template.tags['include'] = CustomInclude
     begin
       assert_equal("custom_foo_if_true",

--- a/test/integration/template_test.rb
+++ b/test/integration/template_test.rb
@@ -80,7 +80,7 @@ class TemplateTest < Minitest::Test
   end
 
   def test_lambda_is_called_once_from_persistent_assigns_over_multiple_parses_and_renders
-    t                   = Template.new
+    t = Template.new
     t.assigns['number'] = -> {
       @global ||= 0
       @global  += 1
@@ -92,7 +92,7 @@ class TemplateTest < Minitest::Test
   end
 
   def test_lambda_is_called_once_from_custom_assigns_over_multiple_parses_and_renders
-    t       = Template.new
+    t = Template.new
     assigns = { 'number' => -> {
                               @global ||= 0
                               @global  += 1
@@ -104,13 +104,13 @@ class TemplateTest < Minitest::Test
   end
 
   def test_resource_limits_works_with_custom_length_method
-    t                                     = Template.parse("{% assign foo = bar %}")
+    t = Template.parse("{% assign foo = bar %}")
     t.resource_limits.render_length_limit = 42
     assert_equal("", t.render!("bar" => SomethingWithLength.new))
   end
 
   def test_resource_limits_render_length
-    t                                     = Template.parse("0123456789")
+    t = Template.parse("0123456789")
     t.resource_limits.render_length_limit = 5
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     assert(t.resource_limits.reached?)
@@ -121,12 +121,12 @@ class TemplateTest < Minitest::Test
   end
 
   def test_resource_limits_render_score
-    t                                    = Template.parse("{% for a in (1..10) %} {% for a in (1..10) %} foo {% endfor %} {% endfor %}")
+    t = Template.parse("{% for a in (1..10) %} {% for a in (1..10) %} foo {% endfor %} {% endfor %}")
     t.resource_limits.render_score_limit = 50
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     assert(t.resource_limits.reached?)
 
-    t                                    = Template.parse("{% for a in (1..100) %} foo {% endfor %}")
+    t = Template.parse("{% for a in (1..100) %} foo {% endfor %}")
     t.resource_limits.render_score_limit = 50
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     assert(t.resource_limits.reached?)
@@ -137,7 +137,7 @@ class TemplateTest < Minitest::Test
   end
 
   def test_resource_limits_assign_score
-    t                                    = Template.parse("{% assign foo = 42 %}{% assign bar = 23 %}")
+    t = Template.parse("{% assign foo = 42 %}{% assign bar = 23 %}")
     t.resource_limits.assign_score_limit = 1
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     assert(t.resource_limits.reached?)
@@ -169,7 +169,7 @@ class TemplateTest < Minitest::Test
   end
 
   def test_resource_limits_aborts_rendering_after_first_error
-    t                                    = Template.parse("{% for a in (1..100) %} foo1 {% endfor %} bar {% for a in (1..100) %} foo2 {% endfor %}")
+    t = Template.parse("{% for a in (1..100) %} foo1 {% endfor %} bar {% for a in (1..100) %} foo2 {% endfor %}")
     t.resource_limits.render_score_limit = 50
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     assert(t.resource_limits.reached?)
@@ -184,19 +184,19 @@ class TemplateTest < Minitest::Test
   end
 
   def test_render_length_persists_between_blocks
-    t                                     = Template.parse("{% if true %}aaaa{% endif %}")
+    t = Template.parse("{% if true %}aaaa{% endif %}")
     t.resource_limits.render_length_limit = 7
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     t.resource_limits.render_length_limit = 8
     assert_equal("aaaa", t.render)
 
-    t                                     = Template.parse("{% if true %}aaaa{% endif %}{% if true %}bbb{% endif %}")
+    t = Template.parse("{% if true %}aaaa{% endif %}{% if true %}bbb{% endif %}")
     t.resource_limits.render_length_limit = 13
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     t.resource_limits.render_length_limit = 14
     assert_equal("aaaabbb", t.render)
 
-    t                                     = Template.parse("{% if true %}a{% endif %}{% if true %}b{% endif %}{% if true %}a{% endif %}{% if true %}b{% endif %}{% if true %}a{% endif %}{% if true %}b{% endif %}")
+    t = Template.parse("{% if true %}a{% endif %}{% if true %}b{% endif %}{% if true %}a{% endif %}{% if true %}b{% endif %}{% if true %}a{% endif %}{% if true %}b{% endif %}")
     t.resource_limits.render_length_limit = 5
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     t.resource_limits.render_length_limit = 11
@@ -206,7 +206,7 @@ class TemplateTest < Minitest::Test
   end
 
   def test_render_length_uses_number_of_bytes_not_characters
-    t                                     = Template.parse("{% if true %}すごい{% endif %}")
+    t = Template.parse("{% if true %}すごい{% endif %}")
     t.resource_limits.render_length_limit = 10
     assert_equal("Liquid error: Memory limits exceeded", t.render)
     t.resource_limits.render_length_limit = 18
@@ -215,7 +215,7 @@ class TemplateTest < Minitest::Test
 
   def test_default_resource_limits_unaffected_by_render_with_context
     context = Context.new
-    t       = Template.parse("{% for a in (1..100) %} {% assign foo = 1 %} {% endfor %}")
+    t = Template.parse("{% for a in (1..100) %} {% assign foo = 1 %} {% endfor %}")
     t.render!(context)
     assert(context.resource_limits.assign_score > 0)
     assert(context.resource_limits.render_score > 0)
@@ -223,9 +223,9 @@ class TemplateTest < Minitest::Test
   end
 
   def test_can_use_drop_as_context
-    t                   = Template.new
+    t = Template.new
     t.registers['lulz'] = 'haha'
-    drop                = TemplateContextDrop.new
+    drop = TemplateContextDrop.new
     assert_equal('fizzbuzz', t.parse('{{foo}}').render!(drop))
     assert_equal('bar', t.parse('{{bar}}').render!(drop))
     assert_equal('haha', t.parse("{{baz}}").render!(drop))
@@ -233,7 +233,7 @@ class TemplateTest < Minitest::Test
 
   def test_render_bang_force_rethrow_errors_on_passed_context
     context = Context.new('drop' => ErroneousDrop.new)
-    t       = Template.new.parse('{{ drop.bad_method }}')
+    t = Template.new.parse('{{ drop.bad_method }}')
 
     e = assert_raises RuntimeError do
       t.render!(context)
@@ -311,8 +311,8 @@ class TemplateTest < Minitest::Test
   end
 
   def test_undefined_drop_methods
-    d      = DropWithUndefinedMethod.new
-    t      = Template.new.parse('{{ foo }} {{ woot }}')
+    d = DropWithUndefinedMethod.new
+    t = Template.new.parse('{{ foo }} {{ woot }}')
     result = t.render(d, strict_variables: true)
 
     assert_equal('foo ', result)
@@ -330,7 +330,7 @@ class TemplateTest < Minitest::Test
   end
 
   def test_undefined_filters
-    t       = Template.parse("{{a}} {{x | upcase | somefilter1 | somefilter2 | somefilter3}}")
+    t = Template.parse("{{a}} {{x | upcase | somefilter1 | somefilter2 | somefilter3}}")
     filters = Module.new do
       def somefilter3(v)
         "-#{v}-"
@@ -353,11 +353,11 @@ class TemplateTest < Minitest::Test
   end
 
   def test_using_range_literal_works_as_expected
-    t      = Template.parse("{% assign foo = (x..y) %}{{ foo }}")
+    t = Template.parse("{% assign foo = (x..y) %}{{ foo }}")
     result = t.render('x' => 1, 'y' => 5)
     assert_equal('1..5', result)
 
-    t      = Template.parse("{% assign nums = (x..y) %}{% for num in nums %}{{ num }}{% endfor %}")
+    t = Template.parse("{% assign nums = (x..y) %}{% for num in nums %}{{ num }}{% endfor %}")
     result = t.render('x' => 1, 'y' => 5)
     assert_equal('12345', result)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,8 +8,8 @@ $LOAD_PATH.unshift(File.join(File.expand_path(__dir__), '..', 'lib'))
 require 'liquid.rb'
 require 'liquid/profiler'
 
-mode                        = :strict
-if (env_mode                = ENV['LIQUID_PARSER_MODE'])
+mode = :strict
+if (env_mode = ENV['LIQUID_PARSER_MODE'])
   puts "-- #{env_mode.upcase} ERROR MODE"
   mode = env_mode.to_sym
 end
@@ -71,7 +71,7 @@ module Minitest
     end
 
     def with_taint_mode(mode)
-      old_mode                    = Liquid::Template.taint_mode
+      old_mode = Liquid::Template.taint_mode
       Liquid::Template.taint_mode = mode
       yield
     ensure
@@ -79,7 +79,7 @@ module Minitest
     end
 
     def with_error_mode(mode)
-      old_mode                    = Liquid::Template.error_mode
+      old_mode = Liquid::Template.error_mode
       Liquid::Template.error_mode = mode
       yield
     ensure

--- a/test/unit/context_unit_test.rb
+++ b/test/unit/context_unit_test.rb
@@ -85,7 +85,7 @@ class ContextUnitTest < Minitest::Test
     @context['date'] = Date.today
     assert_equal(Date.today, @context['date'])
 
-    now                  = Time.now
+    now = Time.now
     @context['datetime'] = now
     assert_equal(now, @context['datetime'])
 
@@ -476,7 +476,7 @@ class ContextUnitTest < Minitest::Test
   def test_apply_global_filter
     global_filter_proc = ->(output) { "#{output} filtered" }
 
-    context               = Context.new
+    context = Context.new
     context.global_filter = global_filter_proc
 
     assert_equal('hi filtered', context.apply_global_filter('hi'))
@@ -498,9 +498,9 @@ class ContextUnitTest < Minitest::Test
   end
 
   def test_new_isolated_subcontext_does_not_inherit_variables
-    super_context                = Context.new
+    super_context = Context.new
     super_context['my_variable'] = 'some value'
-    subcontext                   = super_context.new_isolated_subcontext
+    subcontext = super_context.new_isolated_subcontext
 
     assert_nil(subcontext['my_variable'])
   end
@@ -520,9 +520,9 @@ class ContextUnitTest < Minitest::Test
   end
 
   def test_new_isolated_subcontext_inherits_exception_renderer
-    super_context                    = Context.new
+    super_context = Context.new
     super_context.exception_renderer = ->(_e) { 'my exception message' }
-    subcontext                       = super_context.new_isolated_subcontext
+    subcontext = super_context.new_isolated_subcontext
     assert_equal('my exception message', subcontext.handle_error(Liquid::Error.new))
   end
 

--- a/test/unit/strainer_unit_test.rb
+++ b/test/unit/strainer_unit_test.rb
@@ -72,8 +72,8 @@ class StrainerUnitTest < Minitest::Test
   end
 
   def test_strainer_uses_a_class_cache_to_avoid_method_cache_invalidation
-    a        = Module.new
-    b        = Module.new
+    a = Module.new
+    b = Module.new
     strainer = Strainer.create(nil, [a, b])
     assert_kind_of(Strainer, strainer)
     assert_kind_of(a, strainer)
@@ -82,8 +82,8 @@ class StrainerUnitTest < Minitest::Test
   end
 
   def test_add_filter_when_wrong_filter_class
-    c            = Context.new
-    s            = c.strainer
+    c = Context.new
+    s = c.strainer
     wrong_filter = ->(v) { v.reverse }
 
     assert_raises ArgumentError do


### PR DESCRIPTION
This undoes more whitespace insertion you proposed for the Liquid codebase: `Shopify/liquid#1190`

*Note: This is based entirely on my subjective perception of the affect on readability and doesn't involve a scientific principle.*

You're free to push any changes as you see fit and they'll automatically reflect in the original PR.
**Either ways, please merge this using the `squash-merge` strategy via GitHub UI** so that only a single commit is inserted into the original PR upstream.